### PR TITLE
chore: add Renovate config and EOL enforcement

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,32 @@
+# EditorConfig helps maintain consistent coding styles between different editors and IDEs
+# Recommended placement: repository root (not .github) so it applies to the entire working tree
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+# Python defaults
+[*.py]
+indent_style = space
+indent_size = 4
+
+# YAML uses 2-space indentation
+[*.{yml,yaml}]
+indent_style = space
+indent_size = 2
+
+# ReST and INI/CNF-style files
+[*.{rst,ini,cfg,conf}]
+indent_style = space
+indent_size = 4
+
+# Makefiles require tabs
+[Makefile]
+indent_style = tab
+
+# Allow trailing spaces in Markdown (used for soft line breaks)
+[*.md]
+trim_trailing_whitespace = false

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,34 @@
+# Normalize line endings to LF across the repository
+* text=auto eol=lf
+
+# Common text file overrides (explicit LF)
+*.sh text eol=lf
+*.py text eol=lf
+*.yaml text eol=lf
+*.yml text eol=lf
+*.ini text eol=lf
+*.cfg text eol=lf
+*.conf eol=lf
+*.rst text eol=lf
+*.md text eol=lf
+Makefile text eol=lf
+
+# Binary files (no EOL conversion)
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.pdf binary
+*.zip binary
+*.gz binary
+*.tgz binary
+*.xz binary
+*.bz2 binary
+*.7z binary
+*.woff binary
+*.woff2 binary
+*.ttf binary
+*.eot binary
+*.so binary
+*.dylib binary

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,84 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended"
+  ],
+  "timezone": "Asia/Kolkata",
+  "dependencyDashboard": true,
+  "semanticCommits": "enabled",
+  "rebaseWhen": "behind-base-branch",
+  "prHourlyLimit": 2,
+  "prConcurrentLimit": 5,
+  "labels": [
+    "dependencies",
+    "renovate"
+  ],
+  "schedule": [
+    "before 6am on monday"
+  ],
+  "rangeStrategy": "bump",
+  "packageRules": [
+    {
+      "description": "Automerge safe updates for GitHub Actions and Docker",
+      "matchManagers": [
+        "github-actions",
+        "dockerfile"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
+      "automerge": true,
+      "automergeType": "branch"
+    },
+    {
+      "description": "Conservative policy for Python requirements: disable majors",
+      "matchManagers": [
+        "pip_requirements",
+        "pip_setup",
+        "poetry"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "enabled": false
+    },
+    {
+      "description": "Do not automerge Python minor updates (require review)",
+      "matchManagers": [
+        "pip_requirements",
+        "pip_setup",
+        "poetry"
+      ],
+      "matchUpdateTypes": [
+        "minor"
+      ],
+      "automerge": false
+    },
+    {
+      "description": "Automerge Python patch updates when CI passes",
+      "matchManagers": [
+        "pip_requirements",
+        "pip_setup",
+        "poetry"
+      ],
+ "matchUpdateTypes": [
+        "patch"
+      ],
+      "automerge": true,
+      "automergeType": "branch"
+    },
+    {
+      "description": "Group Python minor/patch updates to reduce PR noise",
+      "matchManagers": [
+        "pip_requirements"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
+      "groupName": "python requirements (minor/patch)",
+      "separateMultipleMajor": true
+    }
+  ]
+}


### PR DESCRIPTION
- Add Renovate configuration in .github/renovate.json
  - Weekly schedule (Monday before 6am Asia/Kolkata)
  - Conservative Python policy: no majors, patch automerge after CI
  - Automerge minor/patch for GitHub Actions and Docker
  - Group updates to reduce PR noise
- Add .editorconfig to enforce LF line endings and final newline
- Add .gitattributes to normalize line endings to LF

Follows sapcc org convention (portunus, archer, mutavault).

Change-Id: Iec58395ada989f5dc77a2dacd9ba0ac2bd515517